### PR TITLE
Add usage readme section

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Print pokemon in the CLI! An adaptation of the classic "cowsay"
 
 - [pokesay](#pokesay)
   - [One-line installs](#one-line-installs)
+  - [Usage](#usage)
   - [How it works](#how-it-works)
   - [Building binaries](#building-binaries)
     - [On your host OS](#on-your-host-os)
@@ -42,6 +43,18 @@ Print pokemon in the CLI! An adaptation of the classic "cowsay"
     bash -c "$(curl https://raw.githubusercontent.com/tmck-code/pokesay/master/build/scripts/install.sh)" bash windows amd64
     ```
 </details>
+
+---
+
+## Usage
+
+Just pipe some text! e.g.
+
+```shell
+echo yolo | pokesay
+```
+
+> _Note: The pokesay tool is intended to only be used with piped text input from STDIN, entering text by typing (or other methods) might not work as expected!_
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,6 @@ Print pokemon in the CLI! An adaptation of the classic "cowsay"
 
 ## One-line installs
 
-<details>
-  <summary>Click to expand!</summary>
-
 - OSX / darwin
     ```shell
     bash -c "$(curl https://raw.githubusercontent.com/tmck-code/pokesay/master/build/scripts/install.sh)" bash darwin amd64
@@ -42,7 +39,6 @@ Print pokemon in the CLI! An adaptation of the classic "cowsay"
     ```shell
     bash -c "$(curl https://raw.githubusercontent.com/tmck-code/pokesay/master/build/scripts/install.sh)" bash windows amd64
     ```
-</details>
 
 ---
 


### PR DESCRIPTION
## Context

An issue was submitted raising a question around pokesay's behaviour when using non-piped input from STDIN

https://github.com/tmck-code/pokesay/issues/7

I explained the decision to add this as documentation in the comment here: https://github.com/tmck-code/pokesay/issues/7#issuecomment-1323547407

## Changes

- Add "usage" section
- Bonus - don't hide/collapse the install commands