### PR TITLE
Reduce the bubble padding by 1

### DIFF
--- a/pokesay.go
+++ b/pokesay.go
@@ -53,7 +53,7 @@ func printSpeechBubbleLine(line string, width int) {
 	if len(line) > width {
 		fmt.Println("|", line)
 	} else {
-		fmt.Println("|", line, strings.Repeat(" ", width-len(line)), "|")
+		fmt.Println("|", line, strings.Repeat(" ", width-len(line)-1), "|")
 	}
 }
 


### PR DESCRIPTION
## Context

The right-hand-side of the speech bubble is not symmetrical with the left, e.g.

```
/----------------------\
| hello world           | <---
\----------------------/
```

vs the correct behaviour

```
/----------------------\
| hello world          | <-----
\----------------------/
```

## Changes

- I decreased the padding by 1