### PR TITLE
Use printf for printing the text bubble

### DIFF
--- a/pokesay.go
+++ b/pokesay.go
@@ -51,9 +51,9 @@ func randomInt(n int) int {
 
 func printSpeechBubbleLine(line string, width int) {
 	if len(line) > width {
-		fmt.Println("|", line)
+		fmt.Printf("| %s\n", line)
 	} else {
-		fmt.Println("|", line, strings.Repeat(" ", width-len(line)-1), "|")
+		fmt.Printf("| %s%s |\n", line, strings.Repeat(" ", width-len(line)))
 	}
 }
 


### PR DESCRIPTION
It's easier for my feeble mind to read, and fixes the "negative repeat" error that currently happens randomly

```
╰─>$ fortune | pokesay -width 20
/----------------------\
panic: strings: negative Repeat count
```

This occurs because of the way the padding was calculated, and happens when the length of the current line and the width are equal

This was to deal the the space that println inserts between each argument. Using printf instead removes the need for this workaround and fixes the bug too