### PR TITLE
Add flag to disable printing the category info

### DIFF
--- a/pokesay.go
+++ b/pokesay.go
@@ -29,6 +29,7 @@ func parseFlags() pokesay.Args {
 	noWrap := flag.Bool("nowrap", false, "disable text wrapping (fastest)")
 	tabWidth := flag.Int("tabwidth", 4, "replace any tab characters with N spaces")
 	noTabSpaces := flag.Bool("notabspaces", false, "do not replace tab characters (fastest)")
+	noCategoryInfo := flag.Bool("nocategoryinfo", false, "do not print pokemon categories")
 	fastest := flag.Bool("fastest", false, "run with the fastest possible configuration (-nowrap -notabspaces)")
 	category := flag.String("category", "", "choose a pokemon from a specific category")
 	name := flag.String("name", "", "choose a pokemon from a specific name")
@@ -52,6 +53,7 @@ func parseFlags() pokesay.Args {
 			NoWrap:         *noWrap,
 			TabSpaces:      strings.Repeat(" ", *tabWidth),
 			NoTabSpaces:    *noTabSpaces,
+			NoCategoryInfo: *noCategoryInfo,
 			ListCategories: *listCategories,
 			ListNames:      *listNames,
 			Category:       *category,

--- a/src/pokesay/print.go
+++ b/src/pokesay/print.go
@@ -22,6 +22,7 @@ type Args struct {
 	NoWrap         bool
 	TabSpaces      string
 	NoTabSpaces    bool
+	NoCategoryInfo bool
 	ListCategories bool
 	ListNames      bool
 	Category       string
@@ -36,7 +37,7 @@ type Args struct {
 // 3. The pokemon is printed along with the name & category information
 func Print(args Args, choice int, names []string, categories []string, cows embed.FS) {
 	printSpeechBubble(bufio.NewScanner(os.Stdin), args.Width, args.NoTabSpaces, args.TabSpaces, args.NoWrap)
-	printPokemon(choice, names, categories, cows)
+	printPokemon(args, choice, names, categories, cows)
 }
 
 // Prints text from STDIN, surrounded by a speech bubble.
@@ -81,7 +82,7 @@ func printWrappedText(line string, width int, tabSpaces string) {
 }
 
 // Prints a pokemon with its name & category information.
-func printPokemon(index int, names []string, categoryKeys []string, GOBCowData embed.FS) {
+func printPokemon(args Args, index int, names []string, categoryKeys []string, GOBCowData embed.FS) {
 	d, _ := GOBCowData.ReadFile(pokedex.EntryFpath("build/assets/cows", index))
 	delimiter := "|"
 
@@ -90,11 +91,19 @@ func printPokemon(index int, names []string, categoryKeys []string, GOBCowData e
 		namesFmt = append(namesFmt, textStyleBold.Sprint(name))
 	}
 
-	fmt.Printf(
-		"%s> %s %s %s\n",
-		pokedex.Decompress(d),
-		strings.Join(namesFmt, fmt.Sprintf(" %s ", delimiter)),
-		delimiter,
-		textStyleItalic.Sprint(strings.Join(categoryKeys, "/")),
-	)
+	if args.NoCategoryInfo {
+		fmt.Printf(
+			"%s> %s\n",
+			pokedex.Decompress(d),
+			strings.Join(namesFmt, fmt.Sprintf(" %s ", delimiter)),
+		)
+	} else {
+		fmt.Printf(
+			"%s> %s %s %s\n",
+			pokedex.Decompress(d),
+			strings.Join(namesFmt, fmt.Sprintf(" %s ", delimiter)),
+			delimiter,
+			textStyleItalic.Sprint(strings.Join(categoryKeys, "/")),
+		)
+	}
 }


### PR DESCRIPTION
## Context

This information is good to have for regular users as it lets them know what categories a chosen pokemon belongs to, allowing them to use that category

However, in most circumstances, the categories are not that interesting and can be skipped.

This results in a cleaner-looking output, and is especially helpful on small/narrow displays

Simply run with `-nocategoryinfo` to use!

---

## Changes

```shell
# before
> pikachu-alola-cap | ピカチュウ (pikachuu) | small/gen8/regular/female

# after (with `-nocategoryinfo` flag)
> pikachu-alola-cap | ピカチュウ (pikachuu)
```

- Added an extra command-line arg, and Arg struct field
- For speed, just use a dumb if statement that either prints the full output, or the output without the category info