### PR TITLE
Make all command line args kebab-case

### DIFF
--- a/pokesay.go
+++ b/pokesay.go
@@ -26,10 +26,10 @@ var (
 
 func parseFlags() pokesay.Args {
 	width := flag.Int("width", 80, "the max speech bubble width")
-	noWrap := flag.Bool("nowrap", false, "disable text wrapping (fastest)")
-	tabWidth := flag.Int("tabwidth", 4, "replace any tab characters with N spaces")
-	noTabSpaces := flag.Bool("notabspaces", false, "do not replace tab characters (fastest)")
-	noCategoryInfo := flag.Bool("nocategoryinfo", false, "do not print pokemon categories")
+	noWrap := flag.Bool("no-wrap", false, "disable text wrapping (fastest)")
+	tabWidth := flag.Int("tab-width", 4, "replace any tab characters with N spaces")
+	noTabSpaces := flag.Bool("no-tab-spaces", false, "do not replace tab characters (fastest)")
+	noCategoryInfo := flag.Bool("no-category-info", false, "do not print pokemon categories")
 	fastest := flag.Bool("fastest", false, "run with the fastest possible configuration (-nowrap -notabspaces)")
 	category := flag.String("category", "", "choose a pokemon from a specific category")
 	name := flag.String("name", "", "choose a pokemon from a specific name")


### PR DESCRIPTION
## Context

Instead of smushing whole words together like -nocategoryinfo, split them up separated by a hyphen, e.g. -no-category-info

## Changes

- convert all combined words in args into kebab-case
	- `-nowrap` -> `-no-wrap`
	- `-tabwidth` -> `-tab-width`
	- `-notabspaces` -> `-no-tab-spaces`
	- `-nocategoryinfo` -> `-no-category-info`

The new complete help now shows:

```shell
Usage of ./pokesay:
  -category string
        choose a pokemon from a specific category
  -fastest
        run with the fastest possible configuration (-nowrap -notabspaces)
  -japanese-name
        print the japanese name
  -list-categories
        list all available categories
  -list-names
        list all available names
  -name string
        choose a pokemon from a specific name
  -no-category-info
        do not print pokemon categories
  -no-tab-spaces
        do not replace tab characters (fastest)
  -no-wrap
        disable text wrapping (fastest)
  -tab-width int
        replace any tab characters with N spaces (default 4)
  -width int
        the max speech bubble width (default 80)

```