### PR TITLE
Info unicode box

### DIFF
--- a/pokesay.go
+++ b/pokesay.go
@@ -32,19 +32,28 @@ var (
 )
 
 func parseFlags() pokesay.Args {
+	// list operations
+	listCategories := flag.Bool("list-categories", false, "list all available categories")
+	listNames := flag.Bool("list-names", false, "list all available names")
+
+	// selection/filtering
+	category := flag.String("category", "", "choose a pokemon from a specific category")
+	name := flag.String("name", "", "choose a pokemon from a specific name")
 	width := flag.Int("width", 80, "the max speech bubble width")
+
+	// speech bubble options
 	noWrap := flag.Bool("no-wrap", false, "disable text wrapping (fastest)")
 	tabWidth := flag.Int("tab-width", 4, "replace any tab characters with N spaces")
 	noTabSpaces := flag.Bool("no-tab-spaces", false, "do not replace tab characters (fastest)")
-	noCategoryInfo := flag.Bool("no-category-info", false, "do not print pokemon categories")
 	fastest := flag.Bool("fastest", false, "run with the fastest possible configuration (-nowrap -notabspaces)")
-	category := flag.String("category", "", "choose a pokemon from a specific category")
-	name := flag.String("name", "", "choose a pokemon from a specific name")
-	listCategories := flag.Bool("list-categories", false, "list all available categories")
-	listNames := flag.Bool("list-names", false, "list all available names")
+
+	// info box options
 	japaneseName := flag.Bool("japanese-name", false, "print the japanese name")
-	unicodeBorders := flag.Bool("unicode-borders", false, "use unicode characters to draw the border around the speech box (and info box if -info-border is enabled)")
+	noCategoryInfo := flag.Bool("no-category-info", false, "do not print pokemon categories")
 	drawInfoBorder := flag.Bool("info-border", false, "draw a border around the info line")
+
+	// other option
+	unicodeBorders := flag.Bool("unicode-borders", false, "use unicode characters to draw the border around the speech box (and info box if -info-border is enabled)")
 
 	flag.Parse()
 	var args pokesay.Args

--- a/pokesay.go
+++ b/pokesay.go
@@ -43,7 +43,8 @@ func parseFlags() pokesay.Args {
 	listCategories := flag.Bool("list-categories", false, "list all available categories")
 	listNames := flag.Bool("list-names", false, "list all available names")
 	japaneseName := flag.Bool("japanese-name", false, "print the japanese name")
-	unicodeBox := flag.Bool("unicode-box", false, "use unicode characters to draw the speech box")
+	unicodeBorders := flag.Bool("unicode-borders", false, "use unicode characters to draw the border around the speech box (and info box if -info-border is enabled)")
+	drawInfoBorder := flag.Bool("info-border", false, "draw a border around the info line")
 
 	flag.Parse()
 	var args pokesay.Args
@@ -68,7 +69,8 @@ func parseFlags() pokesay.Args {
 			Category:       *category,
 			NameToken:      *name,
 			JapaneseName:   *japaneseName,
-			BoxCharacters:  pokesay.DetermineBoxCharacters(*unicodeBox),
+			BoxCharacters:  pokesay.DetermineBoxCharacters(*unicodeBorders),
+			DrawInfoBorder: *drawInfoBorder,
 		}
 	}
 	return args

--- a/src/pokesay/print.go
+++ b/src/pokesay/print.go
@@ -182,22 +182,22 @@ func printPokemon(args Args, index int, names []string, categoryKeys []string, G
 		}
 		width += len(categoryKeys) - 1 + 1 + 2
 	}
-	topBorder := fmt.Sprintf(
-		"%s%s%s\n",
-		args.BoxCharacters.TopLeftCorner,
-		strings.Repeat(args.BoxCharacters.HorizontalEdge, width-2),
-		args.BoxCharacters.TopRightCorner,
-	)
-	bottomBorder := fmt.Sprintf(
-		"%s%s%s\n",
-		args.BoxCharacters.BottomLeftCorner,
-		strings.Repeat(args.BoxCharacters.HorizontalEdge, width-2),
-		args.BoxCharacters.BottomRightCorner,
-	)
+
 	if args.DrawInfoBorder {
-		fmt.Printf(
-			"%s%s%s %s %s\n%s",
-			pokedex.Decompress(d),
+		topBorder := fmt.Sprintf(
+			"%s%s%s",
+			args.BoxCharacters.TopLeftCorner,
+			strings.Repeat(args.BoxCharacters.HorizontalEdge, width-2),
+			args.BoxCharacters.TopRightCorner,
+		)
+		bottomBorder := fmt.Sprintf(
+			"%s%s%s",
+			args.BoxCharacters.BottomLeftCorner,
+			strings.Repeat(args.BoxCharacters.HorizontalEdge, width-2),
+			args.BoxCharacters.BottomRightCorner,
+		)
+		infoLine = fmt.Sprintf(
+			"%s\n%s %s %s\n%s\n",
 			topBorder,
 			args.BoxCharacters.VerticalEdge,
 			infoLine,
@@ -205,10 +205,7 @@ func printPokemon(args Args, index int, names []string, categoryKeys []string, G
 			bottomBorder,
 		)
 	} else {
-		fmt.Printf(
-			"%s%s\n",
-			pokedex.Decompress(d),
-			infoLine,
-		)
+		infoLine = fmt.Sprintf("%s\n", infoLine)
 	}
+	fmt.Printf("%s%s", pokedex.Decompress(d), infoLine)
 }

--- a/src/pokesay/print.go
+++ b/src/pokesay/print.go
@@ -63,7 +63,7 @@ var (
 		BottomRightCorner: "╯",
 		BottomLeftCorner:  "╰",
 		BalloonString:     "╲",
-		Separator:         "┆",
+		Separator:         "│",
 		RightArrow:        "→",
 		CategorySeparator: "/",
 	}

--- a/src/pokesay/print.go
+++ b/src/pokesay/print.go
@@ -150,20 +150,18 @@ func printPokemon(args Args, index int, names []string, categoryKeys []string, G
 	d, _ := GOBCowData.ReadFile(pokedex.EntryFpath("build/assets/cows", index))
 
 	width := nameLength(names)
-	fmt.Println("length", width)
 	namesFmt := make([]string, 0)
 	for _, name := range names {
 		namesFmt = append(namesFmt, textStyleBold.Sprint(name))
 	}
 	// count name separators
-	width += (len(namesFmt) - 1) * 3
-	width += 2 + 2 // for the arrows
+	width += (len(names) - 1) * 3
+	width += 2     // for the arrow
 	width += 2 + 2 // for the end box characters
 
 	infoLine := ""
 
 	if args.NoCategoryInfo {
-		width = len(names[0]) + 3 + 1
 		infoLine = fmt.Sprintf(
 			"%s %s",
 			args.BoxCharacters.RightArrow,
@@ -178,24 +176,30 @@ func printPokemon(args Args, index int, names []string, categoryKeys []string, G
 			args.BoxCharacters.Separator,
 			textStyleItalic.Sprint(strings.Join(categoryKeys, args.BoxCharacters.CategorySeparator)),
 		)
+		for _, category := range categoryKeys {
+			width += len(category)
+		}
+		width += len(categoryKeys) - 1 + 1 + 2
 	}
 	topBorder := fmt.Sprintf(
 		"%s%s%s\n",
 		args.BoxCharacters.TopLeftCorner,
-		strings.Repeat(args.BoxCharacters.HorizontalEdge, width),
+		strings.Repeat(args.BoxCharacters.HorizontalEdge, width-2),
 		args.BoxCharacters.TopRightCorner,
 	)
 	bottomBorder := fmt.Sprintf(
 		"%s%s%s\n",
 		args.BoxCharacters.BottomLeftCorner,
-		strings.Repeat(args.BoxCharacters.HorizontalEdge, width),
+		strings.Repeat(args.BoxCharacters.HorizontalEdge, width-2),
 		args.BoxCharacters.BottomRightCorner,
 	)
 	fmt.Printf(
-		"%s%s%s\n%s",
+		"%s%s%s %s %s\n%s",
 		pokedex.Decompress(d),
 		topBorder,
+		args.BoxCharacters.VerticalEdge,
 		infoLine,
+		args.BoxCharacters.VerticalEdge,
 		bottomBorder,
 	)
 }

--- a/src/pokesay/print.go
+++ b/src/pokesay/print.go
@@ -37,6 +37,7 @@ type Args struct {
 	NameToken      string
 	JapaneseName   bool
 	BoxCharacters  *BoxCharacters
+	DrawInfoBorder bool
 }
 
 var (
@@ -62,7 +63,7 @@ var (
 		BottomRightCorner: "╯",
 		BottomLeftCorner:  "╰",
 		BalloonString:     "╲",
-		Separator:         "│",
+		Separator:         "┆",
 		RightArrow:        "→",
 		CategorySeparator: "/",
 	}
@@ -193,13 +194,21 @@ func printPokemon(args Args, index int, names []string, categoryKeys []string, G
 		strings.Repeat(args.BoxCharacters.HorizontalEdge, width-2),
 		args.BoxCharacters.BottomRightCorner,
 	)
-	fmt.Printf(
-		"%s%s%s %s %s\n%s",
-		pokedex.Decompress(d),
-		topBorder,
-		args.BoxCharacters.VerticalEdge,
-		infoLine,
-		args.BoxCharacters.VerticalEdge,
-		bottomBorder,
-	)
+	if args.DrawInfoBorder {
+		fmt.Printf(
+			"%s%s%s %s %s\n%s",
+			pokedex.Decompress(d),
+			topBorder,
+			args.BoxCharacters.VerticalEdge,
+			infoLine,
+			args.BoxCharacters.VerticalEdge,
+			bottomBorder,
+		)
+	} else {
+		fmt.Printf(
+			"%s%s\n",
+			pokedex.Decompress(d),
+			infoLine,
+		)
+	}
 }


### PR DESCRIPTION
| ascii command | result | result |
|--|--|--|
| `-info-border -no-category-info` | <img width="478" alt="image" src="https://github.com/tmck-code/pokesay/assets/9894426/28306dee-ddc8-41b5-838a-376b68d9650e"> | <img width="478" alt="image" src="https://github.com/tmck-code/pokesay/assets/9894426/1f7b08e6-9b73-4fb7-8f6e-ef2c8e439633"> |
| `-info-border` | <img width="481" alt="image" src="https://github.com/tmck-code/pokesay/assets/9894426/70a05de3-0688-4693-bba4-290a0d496f71"> | <img width="473" alt="image" src="https://github.com/tmck-code/pokesay/assets/9894426/e67a3d61-36f9-43d0-8198-6bb34fe0184d"> |
| `-info-border -japanese-name -no-category-info` | <img width="477" alt="image" src="https://github.com/tmck-code/pokesay/assets/9894426/69fab134-7bba-48f6-b9db-bd0b0cc6b13e"> | <img width="473" alt="image" src="https://github.com/tmck-code/pokesay/assets/9894426/b85519ab-b234-43a0-a0c7-e51e723b49aa"> |
| `-info-border -japanese-name` | <img width="569" alt="image" src="https://github.com/tmck-code/pokesay/assets/9894426/40bf4408-aa2b-4d95-b0ba-b7a74c65a8af"> | <img width="530" alt="image" src="https://github.com/tmck-code/pokesay/assets/9894426/14a1a07f-c6dc-4b99-ae6d-a9c04bdb618a"> | 

This adds a param `-info-border` to draw a border around the info underneath the pokemon. This uses unicode box characters if `-unicode-borders` is set, and uses ascii otherwise.