### PR TITLE
Support filtering by both name and category

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ DEBUG=test go test -v ./test/
 ## TODO
 
 - Short-term
+  - [ ] support long and short cli args (e.g. --name/-n)
+  - [ ] optionally print ID assigned to each pokemon, support deterministic selection via the same ID
 - Longer-term
 - Completed
   - [x] Make the category struct faster to load - currently takes up to 80% of the execution time
@@ -167,3 +169,4 @@ DEBUG=test go test -v ./test/
   - [x] Make data structure to hold categories, names and pokemon
   - [x] Increase speed
   - [x] Improve categories to be more specific than shiny/regular
+  - [x] Filter by both name and category

--- a/pokesay.go
+++ b/pokesay.go
@@ -156,7 +156,7 @@ func runPrintByNameAndCategory(args pokesay.Args) {
 	names := pokedex.ReadStructFromBytes[map[string][]int](GOBAllNames)
 	t.Mark("read name struct")
 
-	metadata, final := pokesay.ChooseByName(names, args.NameToken, GOBCowNames, MetadataRoot, args.Category)
+	metadata, final := pokesay.ChooseByNameAndCategory(names, args.NameToken, GOBCowNames, MetadataRoot, args.Category)
 	t.Mark("find and read metadata")
 
 	pokesay.Print(args, final.EntryIndex, GenerateNames(metadata, args), final.Categories, GOBCowData)

--- a/pokesay.go
+++ b/pokesay.go
@@ -126,7 +126,7 @@ func runPrintByName(args pokesay.Args) {
 	names := pokedex.ReadStructFromBytes[map[string][]int](GOBAllNames)
 	t.Mark("read name struct")
 
-	metadata, final := pokesay.ChooseByName(names, args.NameToken, GOBCowNames, MetadataRoot)
+	metadata, final := pokesay.ChooseByName(names, args.NameToken, GOBCowNames, MetadataRoot, "")
 	t.Mark("find and read metadata")
 
 	pokesay.Print(args, final.EntryIndex, GenerateNames(metadata, args), final.Categories, GOBCowData)
@@ -142,6 +142,22 @@ func runPrintByCategory(args pokesay.Args) {
 	dirPath := pokedex.CategoryDirpath(CategoryRoot, args.Category)
 	dir, _ := GOBCategories.ReadDir(dirPath)
 	metadata, final := pokesay.ChooseByCategory(args.Category, dir, GOBCategories, CategoryRoot, GOBCowNames, MetadataRoot)
+
+	pokesay.Print(args, final.EntryIndex, GenerateNames(metadata, args), final.Categories, GOBCowData)
+	t.Mark("print")
+
+	t.Stop()
+	t.PrintJson()
+}
+
+func runPrintByNameAndCategory(args pokesay.Args) {
+	t := timer.NewTimer("runPrintByNameAndCategory", true)
+
+	names := pokedex.ReadStructFromBytes[map[string][]int](GOBAllNames)
+	t.Mark("read name struct")
+
+	metadata, final := pokesay.ChooseByName(names, args.NameToken, GOBCowNames, MetadataRoot, args.Category)
+	t.Mark("find and read metadata")
 
 	pokesay.Print(args, final.EntryIndex, GenerateNames(metadata, args), final.Categories, GOBCowData)
 	t.Mark("print")
@@ -175,6 +191,8 @@ func main() {
 		runListCategories()
 	} else if args.ListNames {
 		runListNames()
+	} else if args.NameToken != "" && args.Category != "" {
+		runPrintByNameAndCategory(args)
 	} else if args.NameToken != "" {
 		runPrintByName(args)
 	} else if args.Category != "" {

--- a/pokesay.go
+++ b/pokesay.go
@@ -126,7 +126,7 @@ func runPrintByName(args pokesay.Args) {
 	names := pokedex.ReadStructFromBytes[map[string][]int](GOBAllNames)
 	t.Mark("read name struct")
 
-	metadata, final := pokesay.ChooseByName(names, args.NameToken, GOBCowNames, MetadataRoot, "")
+	metadata, final := pokesay.ChooseByName(names, args.NameToken, GOBCowNames, MetadataRoot)
 	t.Mark("find and read metadata")
 
 	pokesay.Print(args, final.EntryIndex, GenerateNames(metadata, args), final.Categories, GOBCowData)

--- a/src/pokesay/lookup.go
+++ b/src/pokesay/lookup.go
@@ -25,6 +25,17 @@ func RandomInt(n int) int {
 	return rand.New(Rand).Intn(n)
 }
 
+// ChooseByCategory chooses a pokemon via a requested category
+// 1. It loads the category search structure and finds the name of a random Pokemon matching the entry
+// e.g. if given the category "small", this function might pick the file `1.cat` in
+// - categories/
+//   - small/
+//   - 1.cat
+//   - 44.cat
+//
+// This file contains entries representing the <pokemon metadata index>/<the pokemon entry index>,
+// e.g. "4/1" would represent 4.metadata, and the 2nd entry in that file
+// 2. Using the indexes, load the corresponding metadata file and entry, and then return it
 func ChooseByCategory(category string, categoryDir []fs.DirEntry, categoryFiles embed.FS, categoryRootDir string, metadataFiles embed.FS, metadataRootDir string) (pokedex.PokemonMetadata, pokedex.PokemonEntryMapping) {
 	if len(categoryDir) == 0 {
 		log.Fatalf("cannot find pokemon by category '%s'", category)

--- a/src/pokesay/lookup.go
+++ b/src/pokesay/lookup.go
@@ -53,7 +53,7 @@ func ListNames(names map[string][]int) []string {
 	return pokedex.GatherMapKeys(names)
 }
 
-func ChooseByName(names map[string][]int, nameToken string, metadataFiles embed.FS, metadataRootDir string, category string) (pokedex.PokemonMetadata, pokedex.PokemonEntryMapping) {
+func fetchMetadataByName(names map[string][]int, nameToken string, metadataFiles embed.FS, metadataRootDir string) pokedex.PokemonMetadata {
 	match := names[nameToken]
 	if len(match) == 0 {
 		log.Fatalf("cannot find pokemon by name '%s'", nameToken)
@@ -64,27 +64,47 @@ func ChooseByName(names map[string][]int, nameToken string, metadataFiles embed.
 		metadataFiles,
 		pokedex.MetadataFpath(metadataRootDir, nameChoice),
 	)
+	return metadata
+
+}
+
+func ChooseByName(names map[string][]int, nameToken string, metadataFiles embed.FS, metadataRootDir string) (pokedex.PokemonMetadata, pokedex.PokemonEntryMapping) {
+	metadata := fetchMetadataByName(
+		names,
+		nameToken,
+		metadataFiles,
+		metadataRootDir,
+	)
 
 	// pick a random entry
-	if category == "" {
-		choice := RandomInt(len(metadata.Entries))
-		return metadata, metadata.Entries[choice]
-		// try to filter by desired category
-	} else {
-		matching := make([]pokedex.PokemonEntryMapping, 0)
-		for _, entry := range metadata.Entries {
-			for _, entryCategory := range entry.Categories {
-				if entryCategory == category {
-					matching = append(matching, entry)
-				}
+	choice := RandomInt(len(metadata.Entries))
+	return metadata, metadata.Entries[choice]
+}
+
+func ChooseByNameAndCategory(names map[string][]int, nameToken string, metadataFiles embed.FS, metadataRootDir string, category string) (pokedex.PokemonMetadata, pokedex.PokemonEntryMapping) {
+	// fetch the metadata of a pokemon matching the nameToken
+	metadata := fetchMetadataByName(
+		names,
+		nameToken,
+		metadataFiles,
+		metadataRootDir,
+	)
+
+	// now try and find a metadata entry that matches the requested category
+	matching := make([]pokedex.PokemonEntryMapping, 0)
+	for _, entry := range metadata.Entries {
+		for _, entryCategory := range entry.Categories {
+			if entryCategory == category {
+				matching = append(matching, entry)
 			}
 		}
-		// if the category is not found for this pokemon, return a random entry
-		if len(matching) == 0 {
-			return metadata, metadata.Entries[RandomInt(len(metadata.Entries))]
-		} else {
-			return metadata, matching[RandomInt(len(matching))]
-		}
+	}
+
+	// if the category is not found for this pokemon, return a random entry
+	if len(matching) == 0 {
+		return metadata, metadata.Entries[RandomInt(len(metadata.Entries))]
+	} else {
+		return metadata, matching[RandomInt(len(matching))]
 	}
 }
 

--- a/src/pokesay/lookup.go
+++ b/src/pokesay/lookup.go
@@ -69,11 +69,10 @@ func ChooseByName(names map[string][]int, nameToken string, metadataFiles embed.
 	if category == "" {
 		choice := RandomInt(len(metadata.Entries))
 		return metadata, metadata.Entries[choice]
-	// try to filter by desired category
+		// try to filter by desired category
 	} else {
 		matching := make([]pokedex.PokemonEntryMapping, 0)
 		for _, entry := range metadata.Entries {
-			log.Printf("entry: %v", entry)
 			for _, entryCategory := range entry.Categories {
 				if entryCategory == category {
 					matching = append(matching, entry)

--- a/test/pokesay_test.go
+++ b/test/pokesay_test.go
@@ -75,6 +75,21 @@ func TestChooseByCategory(test *testing.T) {
 	Assert(expectedEntry, entry, test)
 }
 
+func TestChooseByNameAndCategory(test *testing.T) {
+	names := make(map[string][]int)
+	names["hoothoot"] = []int{4}
+	metadata, entry := pokesay.ChooseByNameAndCategory(
+		names,
+		"hoothoot",
+		GOBCowNames,
+		"data/cows",
+		"small",
+	)
+
+	Assert("small", entry.Categories[0], test)
+	Assert("Hoothoot", metadata.Name, test)
+}
+
 func TestChooseByRandomIndex(test *testing.T) {
 	resultTotal, result := pokesay.ChooseByRandomIndex(GOBTotal)
 	Assert(9, resultTotal, test)


### PR DESCRIPTION
## Context

Woohoo finally! :tada:

This adds the ability to select a Pokémon using a name _and_ a category (previously it chose by only name, or only category)

## Demo

> use both `-name` and `-category` args to use this feature

Behold the glory: 
![Screenshot_20240312-185216](https://github.com/tmck-code/pokesay/assets/9894426/40db7a20-e695-47b9-bac3-90543b6ecbf8)

