### PR TITLE
use getopt for cli args

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,9 +201,10 @@ DEBUG=test go test -v ./test/
 ## TODO
 
 - Short-term
-  - [ ] support long and short cli args (e.g. --name/-n)
   - [ ] optionally print ID assigned to each pokemon, support deterministic selection via the same ID
 - Longer-term
+- In Beta
+  - [x] support long and short cli args (e.g. --name/-n)
 - Completed
   - [x] Make the category struct faster to load - currently takes up to 80% of the execution time
   - [x] Store metadata and names in a more storage-efficient manner

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Print pokemon in the CLI! An adaptation of the classic "cowsay"
 - [pokesay](#pokesay)
   - [One-line installs](#one-line-installs)
   - [Usage](#usage)
+    - [Full Usage](#full-usage)
   - [How it works](#how-it-works)
   - [Building binaries](#building-binaries)
     - [On your host OS](#on-your-host-os)
@@ -63,6 +64,38 @@ echo 'fortune | pokesay' >> $HOME/.bashrc
 ```
 
 > _Note: The pokesay tool is intended to only be used with piped text input from STDIN, entering text by typing (or other methods) might not work as expected!_
+
+### Full Usage
+
+> Run pokesay with `-h` or `--help` to see the full usage
+
+```shell
+Usage: pokesay [-bCfhjLlsuvW] [-c value] [-n value] [-t value] [-w value] [parameters ...]
+ -b, --info-border  draw a border around the info box
+ -c, --category=value
+                    choose a pokemon from a specific category
+ -C, --no-category-info
+                    do not print pokemon category information in the info box
+ -f, --fastest      run with the fastest possible configuration (--nowrap &
+                    --notabspaces)
+ -h, --help         display this help message
+ -j, --japanese-name
+                    print the japanese name in the info box
+ -L, --list-categories
+                    list all available categories
+ -l, --list-names   list all available names
+ -n, --name=value   choose a pokemon from a specific name
+ -s, --no-tab-spaces
+                    do not replace tab characters (fastest)
+ -t, --tab-width=value
+                    replace any tab characters with N spaces [4]
+ -u, --unicode-borders
+                    use unicode characters to draw the border around the speech
+                    box (and info box if --info-border is enabled)
+ -v, --verbose      print verbose output
+ -W, --no-wrap      disable text wrapping (fastest)
+ -w, --width=value  the max speech bubble width [80]
+ ```
 
 ---
 

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
+	github.com/pborman/getopt/v2 v2.1.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	golang.org/x/term v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2Em
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
+github.com/pborman/getopt/v2 v2.1.0 h1:eNfR+r+dWLdWmV8g5OlpyrTYHkhVNxHBdN2cCrJmOEA=
+github.com/pborman/getopt/v2 v2.1.0/go.mod h1:4NtW75ny4eBw9fO1bhtNdYTlZKYX5/tBLtsOpwKIKd0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=

--- a/pokesay.go
+++ b/pokesay.go
@@ -34,6 +34,9 @@ var (
 )
 
 func parseFlags() pokesay.Args {
+	// print usage with -h, --help
+	help := getopt.BoolLong("help", 'h', "display this help message")
+
 	// list operations
 	listCategories := getopt.BoolLong("list-categories", 'L', "list all available categories")
 	listNames := getopt.BoolLong("list-names", 'l', "list all available names")
@@ -84,6 +87,7 @@ func parseFlags() pokesay.Args {
 			JapaneseName:   *japaneseName,
 			BoxCharacters:  pokesay.DetermineBoxCharacters(*unicodeBorders),
 			DrawInfoBorder: *drawInfoBorder,
+			Help:           *help,
 		}
 	}
 	return args
@@ -189,6 +193,12 @@ func runPrintRandom(args pokesay.Args) {
 
 func main() {
 	args := parseFlags()
+	// if the -h/--help flag is set, print usage and exit
+	if args.Help {
+		getopt.Usage()
+		return
+	}
+
 	t := timer.NewTimer("main", true)
 
 	if args.ListCategories {

--- a/pokesay.go
+++ b/pokesay.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"embed"
-	"flag"
 	"fmt"
 	"strings"
 
+	"github.com/pborman/getopt/v2"
 	"github.com/tmck-code/pokesay/src/pokedex"
 	"github.com/tmck-code/pokesay/src/pokesay"
 	"github.com/tmck-code/pokesay/src/timer"
@@ -29,33 +29,37 @@ var (
 	CategoryRoot string = "build/assets/categories"
 	MetadataRoot string = "build/assets/metadata"
 	CowDataRoot  string = "build/assets/cows"
+
+	verbose bool
 )
 
 func parseFlags() pokesay.Args {
 	// list operations
-	listCategories := flag.Bool("list-categories", false, "list all available categories")
-	listNames := flag.Bool("list-names", false, "list all available names")
+	listCategories := getopt.BoolLong("list-categories", 'L', "list all available categories")
+	listNames := getopt.BoolLong("list-names", 'l', "list all available names")
 
 	// selection/filtering
-	category := flag.String("category", "", "choose a pokemon from a specific category")
-	name := flag.String("name", "", "choose a pokemon from a specific name")
-	width := flag.Int("width", 80, "the max speech bubble width")
+	category := getopt.StringLong("category", 'c', "", "choose a pokemon from a specific category")
+	name := getopt.StringLong("name", 'n', "", "choose a pokemon from a specific name")
+	width := getopt.IntLong("width", 'w', 80, "the max speech bubble width")
+
+	getopt.FlagLong(&verbose, "verbose", 'v', "print verbose output", "verbose")
 
 	// speech bubble options
-	noWrap := flag.Bool("no-wrap", false, "disable text wrapping (fastest)")
-	tabWidth := flag.Int("tab-width", 4, "replace any tab characters with N spaces")
-	noTabSpaces := flag.Bool("no-tab-spaces", false, "do not replace tab characters (fastest)")
-	fastest := flag.Bool("fastest", false, "run with the fastest possible configuration (-nowrap -notabspaces)")
+	noWrap := getopt.BoolLong("no-wrap", 'W', "disable text wrapping Long(fastest)")
+	tabWidth := getopt.IntLong("tab-width", 't', 4, "replace any tab characters with N spaces")
+	noTabSpaces := getopt.BoolLong("no-tab-spaces", 's', "do not replace tab characters Long(fastest)")
+	fastest := getopt.BoolLong("fastest", 'f', "run with the fastest possible configuration Long(-nowrap -notabspaces)")
 
 	// info box options
-	japaneseName := flag.Bool("japanese-name", false, "print the japanese name")
-	noCategoryInfo := flag.Bool("no-category-info", false, "do not print pokemon categories")
-	drawInfoBorder := flag.Bool("info-border", false, "draw a border around the info line")
+	japaneseName := getopt.BoolLong("japanese-name", 'j', "print the japanese name")
+	noCategoryInfo := getopt.BoolLong("no-category-info", 'C', "do not print pokemon categories")
+	drawInfoBorder := getopt.BoolLong("info-border", 'b', "draw a border around the info line")
 
 	// other option
-	unicodeBorders := flag.Bool("unicode-borders", false, "use unicode characters to draw the border around the speech box (and info box if -info-border is enabled)")
+	unicodeBorders := getopt.BoolLong("unicode-borders", 'u', "use unicode characters to draw the border around the speech box Long(and info box if -info-border is enabled)")
 
-	flag.Parse()
+	getopt.Parse()
 	var args pokesay.Args
 
 	if *fastest {

--- a/pokesay.go
+++ b/pokesay.go
@@ -37,13 +37,14 @@ func parseFlags() pokesay.Args {
 	// print usage with -h, --help
 	help := getopt.BoolLong("help", 'h', "display this help message")
 
+	// selection/filtering
+	name := getopt.StringLong("name", 'n', "", "choose a pokemon from a specific name")
+	category := getopt.StringLong("category", 'c', "", "choose a pokemon from a specific category")
+
 	// list operations
 	listCategories := getopt.BoolLong("list-categories", 'L', "list all available categories")
 	listNames := getopt.BoolLong("list-names", 'l', "list all available names")
 
-	// selection/filtering
-	category := getopt.StringLong("category", 'c', "", "choose a pokemon from a specific category")
-	name := getopt.StringLong("name", 'n', "", "choose a pokemon from a specific name")
 	width := getopt.IntLong("width", 'w', 80, "the max speech bubble width")
 
 	getopt.FlagLong(&verbose, "verbose", 'v', "print verbose output", "verbose")

--- a/pokesay.go
+++ b/pokesay.go
@@ -32,7 +32,6 @@ var (
 )
 
 func parseFlags() pokesay.Args {
-	// print usage
 	help := getopt.BoolLong("help", 'h', "display this help message")
 	// print verbose output (currently timer output)
 	verbose := getopt.BoolLong("verbose", 'v', "print verbose output", "verbose")
@@ -42,24 +41,24 @@ func parseFlags() pokesay.Args {
 	category := getopt.StringLong("category", 'c', "", "choose a pokemon from a specific category")
 
 	// list operations
-	listCategories := getopt.BoolLong("list-categories", 'L', "list all available categories")
 	listNames := getopt.BoolLong("list-names", 'l', "list all available names")
+	listCategories := getopt.BoolLong("list-categories", 'L', "list all available categories")
 
 	width := getopt.IntLong("width", 'w', 80, "the max speech bubble width")
 
 	// speech bubble options
-	noWrap := getopt.BoolLong("no-wrap", 'W', "disable text wrapping Long(fastest)")
 	tabWidth := getopt.IntLong("tab-width", 't', 4, "replace any tab characters with N spaces")
-	noTabSpaces := getopt.BoolLong("no-tab-spaces", 's', "do not replace tab characters Long(fastest)")
-	fastest := getopt.BoolLong("fastest", 'f', "run with the fastest possible configuration Long(-nowrap -notabspaces)")
+	noWrap := getopt.BoolLong("no-wrap", 'W', "disable text wrapping (fastest)")
+	noTabSpaces := getopt.BoolLong("no-tab-spaces", 's', "do not replace tab characters (fastest)")
+	fastest := getopt.BoolLong("fastest", 'f', "run with the fastest possible configuration (-nowrap -notabspaces)")
 
 	// info box options
-	japaneseName := getopt.BoolLong("japanese-name", 'j', "print the japanese name")
-	noCategoryInfo := getopt.BoolLong("no-category-info", 'C', "do not print pokemon categories")
-	drawInfoBorder := getopt.BoolLong("info-border", 'b', "draw a border around the info line")
+	japaneseName := getopt.BoolLong("japanese-name", 'j', "print the japanese name in the info box")
+	noCategoryInfo := getopt.BoolLong("no-category-info", 'C', "do not print pokemon category information in the info box")
+	drawInfoBorder := getopt.BoolLong("info-border", 'b', "draw a border around the info box")
 
 	// other option
-	unicodeBorders := getopt.BoolLong("unicode-borders", 'u', "use unicode characters to draw the border around the speech box Long(and info box if -info-border is enabled)")
+	unicodeBorders := getopt.BoolLong("unicode-borders", 'u', "use unicode characters to draw the border around the speech box (and info box if -info-border is enabled)")
 
 	getopt.Parse()
 	var args pokesay.Args

--- a/pokesay.go
+++ b/pokesay.go
@@ -72,6 +72,7 @@ func parseFlags() pokesay.Args {
 			TabSpaces:     "    ",
 			NoTabSpaces:   true,
 			BoxCharacters: pokesay.DetermineBoxCharacters(false),
+			Help:          *help,
 		}
 	} else {
 		args = pokesay.Args{

--- a/pokesay.go
+++ b/pokesay.go
@@ -29,13 +29,13 @@ var (
 	CategoryRoot string = "build/assets/categories"
 	MetadataRoot string = "build/assets/metadata"
 	CowDataRoot  string = "build/assets/cows"
-
-	verbose bool
 )
 
 func parseFlags() pokesay.Args {
-	// print usage with -h, --help
+	// print usage
 	help := getopt.BoolLong("help", 'h', "display this help message")
+	// print verbose output (currently timer output)
+	verbose := getopt.BoolLong("verbose", 'v', "print verbose output", "verbose")
 
 	// selection/filtering
 	name := getopt.StringLong("name", 'n', "", "choose a pokemon from a specific name")
@@ -46,8 +46,6 @@ func parseFlags() pokesay.Args {
 	listNames := getopt.BoolLong("list-names", 'l', "list all available names")
 
 	width := getopt.IntLong("width", 'w', 80, "the max speech bubble width")
-
-	getopt.FlagLong(&verbose, "verbose", 'v', "print verbose output", "verbose")
 
 	// speech bubble options
 	noWrap := getopt.BoolLong("no-wrap", 'W', "disable text wrapping Long(fastest)")
@@ -74,6 +72,7 @@ func parseFlags() pokesay.Args {
 			NoTabSpaces:   true,
 			BoxCharacters: pokesay.DetermineBoxCharacters(false),
 			Help:          *help,
+			Verbose:       *verbose,
 		}
 	} else {
 		args = pokesay.Args{
@@ -90,6 +89,7 @@ func parseFlags() pokesay.Args {
 			BoxCharacters:  pokesay.DetermineBoxCharacters(*unicodeBorders),
 			DrawInfoBorder: *drawInfoBorder,
 			Help:           *help,
+			Verbose:        *verbose,
 		}
 	}
 	return args
@@ -137,7 +137,7 @@ func runPrintByName(args pokesay.Args) {
 	t.Mark("read name struct")
 
 	metadata, final := pokesay.ChooseByName(names, args.NameToken, GOBCowNames, MetadataRoot)
-	t.Mark("find and read metadata")
+	t.Mark("find/read metadata")
 
 	pokesay.Print(args, final.EntryIndex, GenerateNames(metadata, args), final.Categories, GOBCowData)
 	t.Mark("print")
@@ -167,7 +167,7 @@ func runPrintByNameAndCategory(args pokesay.Args) {
 	t.Mark("read name struct")
 
 	metadata, final := pokesay.ChooseByNameAndCategory(names, args.NameToken, GOBCowNames, MetadataRoot, args.Category)
-	t.Mark("find and read metadata")
+	t.Mark("find/read metadata")
 
 	pokesay.Print(args, final.EntryIndex, GenerateNames(metadata, args), final.Categories, GOBCowData)
 	t.Mark("print")
@@ -199,6 +199,10 @@ func main() {
 	if args.Help {
 		getopt.Usage()
 		return
+	}
+	if args.Verbose {
+		fmt.Println("Verbose output enabled")
+		timer.DEBUG = true
 	}
 
 	t := timer.NewTimer("main", true)

--- a/pokesay.go
+++ b/pokesay.go
@@ -50,7 +50,7 @@ func parseFlags() pokesay.Args {
 	tabWidth := getopt.IntLong("tab-width", 't', 4, "replace any tab characters with N spaces")
 	noWrap := getopt.BoolLong("no-wrap", 'W', "disable text wrapping (fastest)")
 	noTabSpaces := getopt.BoolLong("no-tab-spaces", 's', "do not replace tab characters (fastest)")
-	fastest := getopt.BoolLong("fastest", 'f', "run with the fastest possible configuration (-nowrap -notabspaces)")
+	fastest := getopt.BoolLong("fastest", 'f', "run with the fastest possible configuration (--nowrap & --notabspaces)")
 
 	// info box options
 	japaneseName := getopt.BoolLong("japanese-name", 'j', "print the japanese name in the info box")
@@ -58,7 +58,7 @@ func parseFlags() pokesay.Args {
 	drawInfoBorder := getopt.BoolLong("info-border", 'b', "draw a border around the info box")
 
 	// other option
-	unicodeBorders := getopt.BoolLong("unicode-borders", 'u', "use unicode characters to draw the border around the speech box (and info box if -info-border is enabled)")
+	unicodeBorders := getopt.BoolLong("unicode-borders", 'u', "use unicode characters to draw the border around the speech box (and info box if --info-border is enabled)")
 
 	getopt.Parse()
 	var args pokesay.Args

--- a/src/pokesay/print.go
+++ b/src/pokesay/print.go
@@ -38,6 +38,7 @@ type Args struct {
 	JapaneseName   bool
 	BoxCharacters  *BoxCharacters
 	DrawInfoBorder bool
+	Help           bool
 }
 
 var (

--- a/src/pokesay/print.go
+++ b/src/pokesay/print.go
@@ -39,6 +39,7 @@ type Args struct {
 	BoxCharacters  *BoxCharacters
 	DrawInfoBorder bool
 	Help           bool
+	Verbose        bool
 }
 
 var (

--- a/src/timer/timer.go
+++ b/src/timer/timer.go
@@ -23,10 +23,10 @@ type Timer struct {
 	Enabled          bool
 }
 
-func NewTimer(name string, alignKeys ...bool) *Timer {
+func NewTimer(name string, boolArgs ...bool) *Timer {
 	align := false
-	if len(alignKeys) == 1 {
-		align = alignKeys[0]
+	if len(boolArgs) == 1 {
+		align = boolArgs[0]
 	}
 	t := &Timer{
 		Name:             name,
@@ -48,7 +48,7 @@ func (t *Timer) Mark(stage string) {
 	}
 	now := time.Now()
 	if t.AlignKeys {
-		stage = fmt.Sprintf("%02d.%-15s", len(t.stageNames), stage)
+		stage = fmt.Sprintf("%02d.%-20s", len(t.stageNames), stage)
 	} else {
 		stage = fmt.Sprintf("%02d.%s", len(t.stageNames), stage)
 	}


### PR DESCRIPTION
## Context

### _**Note: this is a breaking change to the pokesay CLI args**_

---

## Breaking Changes

TL;DR - all args now have two dashes at the beginning instead of one!

e.g.

```shell
# before
echo w | pokesay -name pikachu

# after
echo w | pokesay --name pikachu
```

### Added args

- `-h/--help` show usage/help info
- `-v/--verbose` display the timer info

---

CLI programs aren't groovy to use unless you have some freedom to use short or long args. Up until this point, pokesay has used single-dash go args, e.g.

```shell
echo w | pokesay -name pikachu -unicode-border -width 40
```

I've finally tired of this and thankfully there's a great package `getopt` that provides exactly what I needed - long and short cli args, e.g.

```shell
--name/-n
--category/-c
--info-border/-i
# and so on
```

## Changes

- install the package
- convert existing args to `getopt`

## Usage

```
Usage: pokesay [-bCfhjLlsuvW] [-c value] [-n value] [-t value] [-w value] [parameters ...]
 -b, --info-border  draw a border around the info box
 -c, --category=value
                    choose a pokemon from a specific category
 -C, --no-category-info
                    do not print pokemon category information in the info box
 -f, --fastest      run with the fastest possible configuration (--nowrap &
                    --notabspaces)
 -h, --help         display this help message
 -j, --japanese-name
                    print the japanese name in the info box
 -L, --list-categories
                    list all available categories
 -l, --list-names   list all available names
 -n, --name=value   choose a pokemon from a specific name
 -s, --no-tab-spaces
                    do not replace tab characters (fastest)
 -t, --tab-width=value
                    replace any tab characters with N spaces [4]
 -u, --unicode-borders
                    use unicode characters to draw the border around the speech
                    box (and info box if --info-border is enabled)
 -v, --verbose      print verbose output
 -W, --no-wrap      disable text wrapping (fastest)
 -w, --width=value  the max speech bubble width [80]
```

## Demo

This example

- has unicode borders
- info box with border
- info box with japanese name
- info box without categories
- width of 40
- pokemon matching pikachu
- and also (optionally) ones that have the category "right"
  - i.e. they stand facing the right

`echo w | pokesay -ujbC -w 40 -n pikachu -c right`

<img width="1126" alt="image" src="https://github.com/tmck-code/pokesay/assets/9894426/bfba798b-842b-40af-8372-182d6f234ee1">

