### PR TITLE
fix the width detection for nidoran ♀/♂

### DIFF
--- a/src/pokesay/print.go
+++ b/src/pokesay/print.go
@@ -5,6 +5,7 @@ import (
 	"embed"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/fatih/color"
@@ -69,6 +70,7 @@ var (
 		RightArrow:        "→",
 		CategorySeparator: "/",
 	}
+	SingleWidthCars []string = []string{"♀", "♂"}
 )
 
 func DetermineBoxCharacters(unicodeBox bool) *BoxCharacters {
@@ -135,13 +137,19 @@ func printWrappedText(boxCharacters *BoxCharacters, line string, width int, tabS
 
 func nameLength(names []string) int {
 	totalLen := 0
+
 	for _, name := range names {
 		for _, c := range name {
 			// check if ascii
 			if c < 128 {
 				totalLen++
 			} else {
-				totalLen += 2
+				// check if single width character
+				if slices.Contains(SingleWidthCars, string(c)) {
+					totalLen++
+				} else {
+					totalLen += 2
+				}
 			}
 		}
 	}
@@ -170,7 +178,6 @@ func printPokemon(args Args, index int, names []string, categoryKeys []string, G
 			args.BoxCharacters.RightArrow,
 			strings.Join(namesFmt, fmt.Sprintf(" %s ", args.BoxCharacters.Separator)),
 		)
-
 	} else {
 		infoLine = fmt.Sprintf(
 			"%s %s %s %s",
@@ -182,7 +189,7 @@ func printPokemon(args Args, index int, names []string, categoryKeys []string, G
 		for _, category := range categoryKeys {
 			width += len(category)
 		}
-		width += len(categoryKeys) - 1 + 1 + 2
+		width += len(categoryKeys) - 1 + 1 + 2 // lol why did I do this
 	}
 
 	if args.DrawInfoBorder {

--- a/src/pokesay/print.go
+++ b/src/pokesay/print.go
@@ -142,16 +142,11 @@ func nameLength(names []string) int {
 
 	for _, name := range names {
 		for _, c := range name {
-			// check if ascii
-			if c < 128 {
+			// check if ascii or single-width unicode
+			if (c < 128) || (SingleWidthCars[string(c)]) {
 				totalLen++
 			} else {
-				// check if single width character
-				if SingleWidthCars[string(c)] {
-					totalLen++
-				} else {
-					totalLen += 2
-				}
+				totalLen += 2
 			}
 		}
 	}

--- a/src/pokesay/print.go
+++ b/src/pokesay/print.go
@@ -5,7 +5,6 @@ import (
 	"embed"
 	"fmt"
 	"os"
-	"slices"
 	"strings"
 
 	"github.com/fatih/color"
@@ -70,7 +69,10 @@ var (
 		RightArrow:        "→",
 		CategorySeparator: "/",
 	}
-	SingleWidthCars []string = []string{"♀", "♂"}
+	SingleWidthCars map[string]bool = map[string]bool{
+		"♀": true,
+		"♂": true,
+	}
 )
 
 func DetermineBoxCharacters(unicodeBox bool) *BoxCharacters {
@@ -145,7 +147,7 @@ func nameLength(names []string) int {
 				totalLen++
 			} else {
 				// check if single width character
-				if slices.Contains(SingleWidthCars, string(c)) {
+				if SingleWidthCars[string(c)] {
 					totalLen++
 				} else {
 					totalLen += 2


### PR DESCRIPTION
## Context

The width calculation function for the pokemon names detects and ord value above 128 as double-width as the characters are always Japanese.

The exception to this rule is the male/female chars that appear in Nidoran names `♀/♂` which are single width. I just added a dumb constant to account for this as opposed to actually solving the width detection properly

| before | after |
|--|--|
| <img width="697" alt="image" src="https://github.com/tmck-code/pokesay/assets/9894426/2afeb44d-0030-4e68-ad74-c85a89b5a0fd"> | <img width="564" alt="image" src="https://github.com/tmck-code/pokesay/assets/9894426/cfa07797-6091-4f80-bb06-f02a29d8adb5"> |
| <img width="551" alt="image" src="https://github.com/tmck-code/pokesay/assets/9894426/4f62ea30-1b0e-4d3c-8962-439fc3a6f407"> | <img width="577" alt="image" src="https://github.com/tmck-code/pokesay/assets/9894426/2ad2c5f0-7e9c-4f02-a2d8-72b4f15d416a"> |
