### PR TITLE
add a flag to disable printing the speech bubble

### DIFF
--- a/pokesay.go
+++ b/pokesay.go
@@ -52,6 +52,7 @@ func parseFlags() pokesay.Args {
 	noWrap := getopt.BoolLong("no-wrap", 'W', "disable text wrapping (fastest)")
 	noTabSpaces := getopt.BoolLong("no-tab-spaces", 's', "do not replace tab characters (fastest)")
 	fastest := getopt.BoolLong("fastest", 'f', "run with the fastest possible configuration (--nowrap & --notabspaces)")
+	noBubble := getopt.BoolLong("no-bubble", 'B', "do not draw the speech bubble")
 
 	// info box options
 	japaneseName := getopt.BoolLong("japanese-name", 'j', "print the japanese name in the info box")
@@ -78,6 +79,7 @@ func parseFlags() pokesay.Args {
 		args = pokesay.Args{
 			Width:          *width,
 			NoWrap:         *noWrap,
+			DrawBubble:     !*noBubble,
 			TabSpaces:      strings.Repeat(" ", *tabWidth),
 			NoTabSpaces:    *noTabSpaces,
 			NoCategoryInfo: *noCategoryInfo,
@@ -141,7 +143,7 @@ func runPrintByName(args pokesay.Args) {
 	metadata, final := pokesay.ChooseByName(names, args.NameToken, GOBCowNames, MetadataRoot)
 	t.Mark("find/read metadata")
 
-	pokesay.Print(args, final.EntryIndex, GenerateNames(metadata, args), final.Categories, GOBCowData)
+	pokesay.Print(args, final.EntryIndex, GenerateNames(metadata, args), final.Categories, GOBCowData, args.DrawBubble)
 	t.Mark("print")
 
 	t.Stop()
@@ -164,7 +166,7 @@ func runPrintByCategory(args pokesay.Args) {
 	dir, _ := GOBCategories.ReadDir(dirPath)
 	metadata, final := pokesay.ChooseByCategory(args.Category, dir, GOBCategories, CategoryRoot, GOBCowNames, MetadataRoot)
 
-	pokesay.Print(args, final.EntryIndex, GenerateNames(metadata, args), final.Categories, GOBCowData)
+	pokesay.Print(args, final.EntryIndex, GenerateNames(metadata, args), final.Categories, GOBCowData, args.DrawBubble)
 	t.Mark("print")
 
 	t.Stop()
@@ -184,7 +186,7 @@ func runPrintByNameAndCategory(args pokesay.Args) {
 	metadata, final := pokesay.ChooseByNameAndCategory(names, args.NameToken, GOBCowNames, MetadataRoot, args.Category)
 	t.Mark("find/read metadata")
 
-	pokesay.Print(args, final.EntryIndex, GenerateNames(metadata, args), final.Categories, GOBCowData)
+	pokesay.Print(args, final.EntryIndex, GenerateNames(metadata, args), final.Categories, GOBCowData, args.DrawBubble)
 	t.Mark("print")
 
 	t.Stop()
@@ -207,7 +209,7 @@ func runPrintRandom(args pokesay.Args) {
 	final := metadata.Entries[pokesay.RandomInt(len(metadata.Entries))]
 	t.Mark("choose entry")
 
-	pokesay.Print(args, final.EntryIndex, GenerateNames(metadata, args), final.Categories, GOBCowData)
+	pokesay.Print(args, final.EntryIndex, GenerateNames(metadata, args), final.Categories, GOBCowData, args.DrawBubble)
 	t.Mark("print")
 
 	t.Stop()

--- a/src/pokesay/print.go
+++ b/src/pokesay/print.go
@@ -20,6 +20,7 @@ type BoxCharacters struct {
 	BottomRightCorner string
 	BottomLeftCorner  string
 	BalloonString     string
+	BalloonTether	  string
 	Separator         string
 	RightArrow        string
 	CategorySeparator string
@@ -54,6 +55,7 @@ var (
 		BottomRightCorner: "/",
 		BottomLeftCorner:  "\\",
 		BalloonString:     "\\",
+		BalloonTether:     "¡",
 		Separator:         "|",
 		RightArrow:        ">",
 		CategorySeparator: "/",
@@ -66,6 +68,7 @@ var (
 		BottomRightCorner: "╯",
 		BottomLeftCorner:  "╰",
 		BalloonString:     "╲",
+		BalloonTether:     "🯓",
 		Separator:         "│",
 		RightArrow:        "→",
 		CategorySeparator: "/",
@@ -96,9 +99,13 @@ func Print(args Args, choice int, names []string, categories []string, cows embe
 
 // Prints text from STDIN, surrounded by a speech bubble.
 func printSpeechBubble(boxCharacters *BoxCharacters, scanner *bufio.Scanner, width int, noTabSpaces bool, tabSpaces string, noWrap bool, drawBubble bool) {
-	border := strings.Repeat(boxCharacters.HorizontalEdge, width+2)
 	if drawBubble {
-		fmt.Println(boxCharacters.TopLeftCorner + border + boxCharacters.TopRightCorner)
+		fmt.Printf(
+			"%s%s%s\n",
+			boxCharacters.TopLeftCorner,
+			strings.Repeat(boxCharacters.HorizontalEdge, width+2),
+			boxCharacters.TopRightCorner,
+		)
 	}
 
 	for scanner.Scan() {
@@ -113,13 +120,18 @@ func printSpeechBubble(boxCharacters *BoxCharacters, scanner *bufio.Scanner, wid
 			printWrappedText(boxCharacters, line, width, tabSpaces, drawBubble)
 		}
 	}
+
+	bottomBorder := strings.Repeat(boxCharacters.HorizontalEdge, 6) +
+		boxCharacters.BalloonTether +
+		strings.Repeat(boxCharacters.HorizontalEdge, width+2-7)
+
 	if drawBubble {
-		fmt.Println(boxCharacters.BottomLeftCorner + border + boxCharacters.BottomRightCorner)
+		fmt.Printf("%s%s%s\n", boxCharacters.BottomLeftCorner, bottomBorder, boxCharacters.BottomRightCorner)
 	} else {
-		fmt.Println(" " + border + " ")
+		fmt.Printf(" %s \n", bottomBorder)
 	}
 	for i := 0; i < 4; i++ {
-		fmt.Println(strings.Repeat(" ", i+8), boxCharacters.BalloonString)
+		fmt.Printf("%s%s\n", strings.Repeat(" ", i+8), boxCharacters.BalloonString)
 	}
 }
 
@@ -183,8 +195,7 @@ func printPokemon(args Args, index int, names []string, categoryKeys []string, G
 	if args.NoCategoryInfo {
 		infoLine = fmt.Sprintf(
 			"%s %s",
-			args.BoxCharacters.RightArrow,
-			strings.Join(namesFmt, fmt.Sprintf(" %s ", args.BoxCharacters.Separator)),
+			args.BoxCharacters.RightArrow, strings.Join(namesFmt, fmt.Sprintf(" %s ", args.BoxCharacters.Separator)),
 		)
 	} else {
 		infoLine = fmt.Sprintf(
@@ -203,23 +214,15 @@ func printPokemon(args Args, index int, names []string, categoryKeys []string, G
 	if args.DrawInfoBorder {
 		topBorder := fmt.Sprintf(
 			"%s%s%s",
-			args.BoxCharacters.TopLeftCorner,
-			strings.Repeat(args.BoxCharacters.HorizontalEdge, width-2),
-			args.BoxCharacters.TopRightCorner,
+			args.BoxCharacters.TopLeftCorner, strings.Repeat(args.BoxCharacters.HorizontalEdge, width-2), args.BoxCharacters.TopRightCorner,
 		)
 		bottomBorder := fmt.Sprintf(
 			"%s%s%s",
-			args.BoxCharacters.BottomLeftCorner,
-			strings.Repeat(args.BoxCharacters.HorizontalEdge, width-2),
-			args.BoxCharacters.BottomRightCorner,
+			args.BoxCharacters.BottomLeftCorner, strings.Repeat(args.BoxCharacters.HorizontalEdge, width-2), args.BoxCharacters.BottomRightCorner,
 		)
 		infoLine = fmt.Sprintf(
 			"%s\n%s %s %s\n%s\n",
-			topBorder,
-			args.BoxCharacters.VerticalEdge,
-			infoLine,
-			args.BoxCharacters.VerticalEdge,
-			bottomBorder,
+			topBorder, args.BoxCharacters.VerticalEdge, infoLine, args.BoxCharacters.VerticalEdge, bottomBorder,
 		)
 	} else {
 		infoLine = fmt.Sprintf("%s\n", infoLine)

--- a/src/pokesay/print.go
+++ b/src/pokesay/print.go
@@ -107,7 +107,7 @@ func printSpeechBubble(boxCharacters *BoxCharacters, scanner *bufio.Scanner, wid
 		if !noTabSpaces {
 			line = strings.Replace(line, "\t", tabSpaces, -1)
 		}
-		if noWrap || !drawBubble {
+		if noWrap {
 			printSpeechBubbleLine(boxCharacters, line, width, drawBubble)
 		} else {
 			printWrappedText(boxCharacters, line, width, tabSpaces, drawBubble)
@@ -115,6 +115,8 @@ func printSpeechBubble(boxCharacters *BoxCharacters, scanner *bufio.Scanner, wid
 	}
 	if drawBubble {
 		fmt.Println(boxCharacters.BottomLeftCorner + border + boxCharacters.BottomRightCorner)
+	} else {
+		fmt.Println(" " + border + " ")
 	}
 	for i := 0; i < 4; i++ {
 		fmt.Println(strings.Repeat(" ", i+8), boxCharacters.BalloonString)


### PR DESCRIPTION
## Context

I've been playing around with ANSI colours in the terminal recently and realised that pokesay doesn't quite support it - essentially the colour codes are miscounted which results in the sides of the bubble looking all out of whack.

I'm going to implement a lolcat-style feature and other colour support in future, but until then this problem can be mitigated by adding a mode/arg that disables printing the bubble

Use for when a cleaner look is desired, or when printing text that doesn't currently gel with the line wrapping and bubble outline

## Changes

- add a new command-line flag `-B` / `--no-bubble` to disable print the bubble
- keep the bottom line of the bubble, as it looks slightly better than having the balloon string floating along, or no bubble elements at all

> Note: the line wrapping is still enabled, but can be disabled too with the `-W` flag

## Bonus

I added a small character that connects the balloon string to the balloon/bubble in both ascii and unicode mode

<img width="717" alt="image" src="https://github.com/user-attachments/assets/9ff25d9b-2448-4778-b23c-e87ed8828ac1">
