### PR TITLE
Balloon tether symbol

### DIFF
--- a/src/pokesay/print.go
+++ b/src/pokesay/print.go
@@ -68,7 +68,7 @@ var (
 		BottomRightCorner: "╯",
 		BottomLeftCorner:  "╰",
 		BalloonString:     "╲",
-		BalloonTether:     "𜺯",
+		BalloonTether:     "╲",
 		Separator:         "│",
 		RightArrow:        "→",
 		CategorySeparator: "/",

--- a/src/pokesay/print.go
+++ b/src/pokesay/print.go
@@ -68,7 +68,7 @@ var (
 		BottomRightCorner: "╯",
 		BottomLeftCorner:  "╰",
 		BalloonString:     "╲",
-		BalloonTether:     "🯓",
+		BalloonTether:     "𜺯",
 		Separator:         "│",
 		RightArrow:        "→",
 		CategorySeparator: "/",


### PR DESCRIPTION
The new symbol for connecting the balloon string to the balloon/bubble isn't supported on mobile, switching to a more supported alternative (a continuation of the string)

<img width="490" alt="image" src="https://github.com/user-attachments/assets/b9b28415-4089-45e9-84e0-2f6a32dad939">
