### PR TITLE
calculate unicode string length properly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/fatih/color v1.18.0
+	github.com/mattn/go-runewidth v0.0.16
 	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/pborman/getopt/v2 v2.1.0
 	github.com/schollz/progressbar/v3 v3.13.1
@@ -12,7 +13,6 @@ require (
 require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	golang.org/x/sys v0.26.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,9 @@ github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
-github.com/mattn/go-runewidth v0.0.14 h1:+xnbZSEeDbOIg5/mE6JF0w6n9duR1l3/WmbinWVwUuU=
 github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
+github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2EmQ4l5rM/4FEfDWcRD+abF5XlKShorW5LRoQ=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=

--- a/test/pokesay_test.go
+++ b/test/pokesay_test.go
@@ -96,3 +96,20 @@ func TestChooseByRandomIndex(test *testing.T) {
 	Assert(0 <= result, true, test)
 	Assert(9 >= result, true, test)
 }
+
+func TestUnicodeStringLength(test *testing.T) {
+	msg := []string{
+		" ▄  █ ▄███▄   █    █    ████▄       ▄ ▄   ████▄ █▄▄▄▄ █     ██▄",   // 63
+		"█   █ █▀   ▀  █    █    █   █      █   █  █   █ █  ▄▀ █     █  █",  // 64
+		"██▀▀█ ██▄▄    █    █    █   █     █ ▄   █ █   █ █▀▀▌  █     █   █", // 65
+		"█   █ █▄   ▄▀ ███▄ ███▄ ▀████     █  █  █ ▀████ █  █  ███▄  █  █",  // 64
+		"   █  ▀███▀       ▀    ▀           █ █ █          █       ▀ ███▀",  // 64
+		"  ▀                                 ▀ ▀          ▀",                // 50
+	}
+	expected := []int{63, 64, 65, 64, 64, 50}
+	results := make([]int, len(msg))
+	for i, line := range msg {
+		results[i] = pokesay.UnicodeStringLength(line)
+	}
+	Assert(expected, results, test)
+}


### PR DESCRIPTION
## Context

Currently, pokesay doesn't calculate line length correctly if it involves unicode double-width characters, and/or ANSI colour codes.

This means that using figlet/lolcat doesn't look nice currently

## Changes

- use the runewidth library for calculating width of each unicode char
- ignore ansi escape codes when counting length
- add basic test for behaviour

![image](https://github.com/user-attachments/assets/59eee904-0da0-4523-b3d0-4e7160fddcf7)


<details>
  <summary>before</summary>

![image](https://github.com/user-attachments/assets/dedb8a88-0795-40ef-a237-da9f224504f5)

</details>


<details>
  <summary>after</summary>

![image](https://github.com/user-attachments/assets/a248b7d9-0999-454f-9bfe-a2e297c3c179)

</details>