### PR TITLE
use a single global debug timer

### DIFF
--- a/build/read_assets.go
+++ b/build/read_assets.go
@@ -45,7 +45,6 @@ func EntryFpath(idx int) string {
 
 func main() {
 	args := parseFlags()
-	t := timer.NewTimer("read_assets", true)
 
 	var metadata pokedex.PokemonMetadata
 
@@ -57,18 +56,18 @@ func main() {
 		metadata = pokedex.ReadMetadataFromFile(fpath)
 	}
 
-	t.Mark("metadata")
+	timer.DebugTimer.Mark("metadata")
 
 	fmt.Println(pokedex.StructToJSON(metadata, 2))
-	t.Mark("toJSON")
+	timer.DebugTimer.Mark("toJSON")
 
 	for i, entry := range metadata.Entries {
 		data := string(pokedex.ReadPokemonCow(GOBCowFiles, EntryFpath(entry.EntryIndex)))
-		t.Mark(fmt.Sprintf("read-cow-%d", i))
+		timer.DebugTimer.Mark(fmt.Sprintf("read-cow-%d", i))
 
 		fmt.Printf("%s\n%s\n", entry.Categories, data)
-		t.Mark(fmt.Sprintf("print-cow-%d", i))
+		timer.DebugTimer.Mark(fmt.Sprintf("print-cow-%d", i))
 	}
-	t.Stop()
-	t.PrintJson()
+	timer.DebugTimer.Stop()
+	timer.DebugTimer.PrintJson()
 }

--- a/pokesay.go
+++ b/pokesay.go
@@ -203,7 +203,11 @@ func runPrintRandom(args pokesay.Args) {
 }
 
 func main() {
+	timer.DebugTimer.Mark("started main")
+
 	args := parseFlags()
+	timer.DebugTimer.Mark("parsed flags")
+
 	// if the -h/--help flag is set, print usage and exit
 	if args.Help {
 		getopt.Usage()
@@ -213,8 +217,6 @@ func main() {
 		fmt.Println("Verbose output enabled")
 		timer.DEBUG = true
 	}
-
-	timer.DebugTimer.Mark("parsed flags")
 
 	if args.ListCategories {
 		runListCategories()
@@ -229,7 +231,8 @@ func main() {
 	} else {
 		runPrintRandom(args)
 	}
-	timer.DebugTimer.Mark("op")
+
+	timer.DebugTimer.Mark("finish")
 
 	timer.DebugTimer.Stop()
 	timer.DebugTimer.PrintJson()

--- a/src/pokedex/metadata.go
+++ b/src/pokedex/metadata.go
@@ -42,29 +42,23 @@ func ReadMetadataFromBytes(data []byte) PokemonMetadata {
 }
 
 func ReadMetadataFromFile(fpath string) PokemonMetadata {
-	t := timer.NewTimer("ReadMetadataFromEmbedded")
 	metadata, err := os.ReadFile(fpath)
 	Check(err)
-	t.Mark("read file")
+	timer.DebugTimer.Mark("read file")
 
 	data := ReadMetadataFromBytes(metadata)
-	t.Mark("read metadata")
+	timer.DebugTimer.Mark("read metadata")
 
-	t.Stop()
-	t.PrintJson()
 	return data
 }
 
 func ReadMetadataFromEmbedded(embeddedData embed.FS, fpath string) PokemonMetadata {
-	t := timer.NewTimer("ReadMetadataFromEmbedded")
 	metadata, err := embeddedData.ReadFile(fpath)
 	Check(err)
-	t.Mark("read file")
+	timer.DebugTimer.Mark("read embedded file")
 
 	data := ReadMetadataFromBytes(metadata)
-	t.Mark("read metadata")
+	timer.DebugTimer.Mark("metadata from bytes")
 
-	t.Stop()
-	t.PrintJson()
 	return data
 }

--- a/src/pokesay/lookup.go
+++ b/src/pokesay/lookup.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/tmck-code/pokesay/src/pokedex"
+	"github.com/tmck-code/pokesay/src/timer"
 )
 
 var (
@@ -41,11 +42,13 @@ func ChooseByCategory(category string, categoryDir []fs.DirEntry, categoryFiles 
 		log.Fatalf("cannot find pokemon by category '%s'", category)
 	}
 	choice := categoryDir[RandomInt(len(categoryDir))]
+	timer.DebugTimer.Mark("choose category")
 
 	categoryMetadata, err := categoryFiles.ReadFile(
 		pokedex.CategoryFpath(categoryRootDir, category, choice.Name()),
 	)
 	pokedex.Check(err)
+	timer.DebugTimer.Mark("read category file")
 
 	parts := strings.Split(string(categoryMetadata), "/")
 
@@ -70,6 +73,7 @@ func fetchMetadataByName(names map[string][]int, nameToken string, metadataFiles
 		log.Fatalf("cannot find pokemon by name '%s'", nameToken)
 	}
 	nameChoice := match[RandomInt(len(match))]
+	timer.DebugTimer.Mark("choose random name")
 
 	metadata := pokedex.ReadMetadataFromEmbedded(
 		metadataFiles,

--- a/src/pokesay/print.go
+++ b/src/pokesay/print.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mattn/go-runewidth"
 	"github.com/mitchellh/go-wordwrap"
 	"github.com/tmck-code/pokesay/src/pokedex"
+	"github.com/tmck-code/pokesay/src/timer"
 )
 
 type BoxChars struct {
@@ -97,6 +98,7 @@ func DetermineBoxChars(unicodeBox bool) *BoxChars {
 // 3. The pokemon is printed along with the name & category information
 func Print(args Args, choice int, names []string, categories []string, cows embed.FS) {
 	printSpeechBubble(args.BoxChars, bufio.NewScanner(os.Stdin), args)
+
 	printPokemon(args, choice, names, categories, cows)
 }
 
@@ -123,6 +125,7 @@ func printSpeechBubble(boxChars *BoxChars, scanner *bufio.Scanner, args Args) {
 			printWrappedText(boxChars, line, args)
 		}
 	}
+	timer.DebugTimer.Mark("scan stdin")
 
 	bottomBorder := strings.Repeat(boxChars.HorizontalEdge, 6) +
 		boxChars.BalloonTether +
@@ -136,6 +139,7 @@ func printSpeechBubble(boxChars *BoxChars, scanner *bufio.Scanner, args Args) {
 	for i := 0; i < 4; i++ {
 		fmt.Printf("%s%s\n", strings.Repeat(" ", i+8), boxChars.BalloonString)
 	}
+	timer.DebugTimer.Mark("print speech bubble")
 }
 
 // Prints a single speech bubble line
@@ -357,6 +361,7 @@ func ReverseANSIString(lines [][]ANSILineToken) [][]ANSILineToken {
 // Prints a pokemon with its name & category information.
 func printPokemon(args Args, index int, names []string, categoryKeys []string, GOBCowData embed.FS) {
 	d, _ := GOBCowData.ReadFile(pokedex.EntryFpath("build/assets/cows", index))
+	timer.DebugTimer.Mark("read sprite file")
 
 	width := nameLength(names)
 	namesFmt := make([]string, 0)
@@ -405,13 +410,20 @@ func printPokemon(args Args, index int, names []string, categoryKeys []string, G
 	} else {
 		infoLine = fmt.Sprintf("%s\n", infoLine)
 	}
+	timer.DebugTimer.Mark("generate string")
 	if args.FlipPokemon {
-		fmt.Printf(
-			"%s%s",
-			BuildANSIString(ReverseANSIString(TokeniseANSIString(string(pokedex.Decompress(d)))), 4),
-			infoLine,
-		)
+		dec := pokedex.Decompress(d)
+		timer.DebugTimer.Mark("gunzip string")
+
+		flipped := BuildANSIString(ReverseANSIString(TokeniseANSIString(string(dec))), 4)
+		timer.DebugTimer.Mark("reverse string")
+
+		fmt.Printf("%s%s", flipped, infoLine)
 	} else {
-		fmt.Printf("%s%s", pokedex.Decompress(d), infoLine)
+		dec := pokedex.Decompress(d)
+		timer.DebugTimer.Mark("gunzip string")
+
+		fmt.Printf("%s%s", dec, infoLine)
 	}
+	timer.DebugTimer.Mark("print to terminal")
 }

--- a/src/timer/timer.go
+++ b/src/timer/timer.go
@@ -10,6 +10,7 @@ import (
 
 var (
 	DEBUG bool = os.Getenv("DEBUG") != ""
+	DebugTimer *Timer = NewTimer("Debug Timer", true)
 )
 
 // Timer is a simple timer that can be used to time the duration of program stages.
@@ -101,6 +102,5 @@ func (t *Timer) PrintJson() {
 		return
 	}
 	json, _ := json.MarshalIndent(t, "", strings.Repeat(" ", 2))
-	// json, _ := json.Marshal(t)
 	fmt.Fprintln(os.Stderr, string(json))
 }


### PR DESCRIPTION
## :watch: Debug Timer Update :timer_clock:

There is a debug timer that can be enabled by setting the `DEBUG` ENV var

At various points in the code, `t.Mark("my checkpoint")` is called which creates a checkpoint, and these are later broken down and summarised in the JSON output

<details>
<summary>example</summary>

```JSON
{
  "Name": "ReadMetadataFromEmbedded",
  "StageTimes": {
    "00.Start": "2025-09-19T06:59:05.021184662+10:00",
    "01.read file": "2025-09-19T06:59:05.021195693+10:00",
    "02.read metadata": "2025-09-19T06:59:05.021271355+10:00"
  },
  "StageDurations": {
    "00.Start": 0,
    "01.read file": 11031,
    "02.read metadata": 75662
  },
  "StagePercentages": {
    "00.Start": "0.0%",
    "01.read file": "12.72%",
    "02.read metadata": "87.28%"
  },
  "Total": 86693,
  "AlignKeys": false,
  "Enabled": true
}
╭──────────────────────────────────────────────────────────────────────────────────╮
│ w                                                                                │
╰──────╲───────────────────────────────────────────────────────────────────────────╯
        ╲
         ╲
          ╲
           ╲
       ▄▄▄▄

     ▄▄▄▄ ▄▄▄
    ▄▄▄▄ ▄▄▄▄▄
       ▄▄   ▄
      ▄▄▄ ▄ ▄▀
     ▄▄▄▄▄ ▄▄
       ▄▄▄▄
      ▄▀▄▄▀▄
    ▀▄▀
            ▀
╭───────────────────────────────────────────────────╮
│ → Unown │ アンノーン (anno-n) │ small/gen7x/shiny │
╰───────────────────────────────────────────────────╯
{
  "Name": "runPrintRandom",
  "StageTimes": {
    "00.Start               ": "2025-09-19T06:59:05.0211782+10:00",
    "01.choose index        ": "2025-09-19T06:59:05.021183029+10:00",
    "02.read metadata       ": "2025-09-19T06:59:05.021369058+10:00",
    "03.choose entry        ": "2025-09-19T06:59:05.02136999+10:00",
    "04.print               ": "2025-09-19T06:59:05.021454839+10:00"
  },
  "StageDurations": {
    "00.Start               ": 0,
    "01.choose index        ": 4829,
    "02.read metadata       ": 186029,
    "03.choose entry        ": 932,
    "04.print               ": 84849
  },
  "StagePercentages": {
    "00.Start               ": "0.0%",
    "01.choose index        ": "1.75%",
    "02.read metadata       ": "67.25%",
    "03.choose entry        ": "0.34%",
    "04.print               ": "30.67%"
  },
  "Total": 276639,
  "AlignKeys": true,
  "Enabled": true
}
{
  "Name": "main",
  "StageTimes": {
    "00.Start               ": "2025-09-19T06:59:05.021173441+10:00",
    "01.op                  ": "2025-09-19T06:59:05.021489234+10:00"
  },
  "StageDurations": {
    "00.Start               ": 0,
    "01.op                  ": 315783
  },
  "StagePercentages": {
    "00.Start               ": "0.0%",
    "01.op                  ": "100.00%"
  },
  "Total": 315783,
  "AlignKeys": true,
  "Enabled": true
}
```

</details>

Currently, there are several timers created by different modules, and they are all rendered and counted separately, which makes comparing different parts of the program a little tedious.

---

## Introducing, a single global timer! :earth_asia: 

- in the timer util, create an exported var `DebugTimer`
- then, in all the various low-level functions, call `.Mark` on the `timer.DebugTimer`
- finally, in the main/run method, stop the timer and render the output before exiting

Overall, this change simplifies the current implementation and usage, reduces the amount of code, and improves the functionality of this dev/debug feature

<details>
<summary>example screenshot</summary>

<img width="376" height="962" alt="image" src="https://github.com/user-attachments/assets/759be069-a268-47d5-a983-8333b34ae995" />
</details>

<details>
<summary>JSON</summary>

```json
{
  "Name": "Debug Timer",
  "StageTimes": {
    "00.Start               ": "2025-09-18T19:15:41.631916+10:00",
    "01.parsed flags        ": "2025-09-18T19:15:41.632431+10:00",
    "02.choose index        ": "2025-09-18T19:15:41.632446+10:00",
    "03.read embedded file  ": "2025-09-18T19:15:41.632513+10:00",
    "04.metadata from bytes ": "2025-09-18T19:15:41.632619+10:00",
    "05.choose entry        ": "2025-09-18T19:15:41.63262+10:00",
    "06.generate names      ": "2025-09-18T19:15:41.632622+10:00",
    "07.scan stdin          ": "2025-09-18T19:15:41.632671+10:00",
    "08.print speech bubble ": "2025-09-18T19:15:41.632683+10:00",
    "09.read sprite file    ": "2025-09-18T19:15:41.63279+10:00",
    "10.generate string     ": "2025-09-18T19:15:41.632806+10:00",
    "11.gunzip string       ": "2025-09-18T19:15:41.632878+10:00",
    "12.reverse string      ": "2025-09-18T19:15:41.633501+10:00",
    "13.print to terminal   ": "2025-09-18T19:15:41.634136+10:00",
    "14.op                  ": "2025-09-18T19:15:41.634139+10:00"
  },
  "StageDurations": {
    "00.Start               ": 0,
    "01.parsed flags        ": 515541,
    "02.choose index        ": 14875,
    "03.read embedded file  ": 66459,
    "04.metadata from bytes ": 106375,
    "05.choose entry        ": 1375,
    "06.generate names      ": 1750,
    "07.scan stdin          ": 49125,
    "08.print speech bubble ": 11583,
    "09.read sprite file    ": 107583,
    "10.generate string     ": 15125,
    "11.gunzip string       ": 72792,
    "12.reverse string      ": 623000,
    "13.print to terminal   ": 634208,
    "14.op                  ": 2959
  },
  "StagePercentages": {
    "00.Start               ": "0.0%",
    "01.parsed flags        ": "23.19%",
    "02.choose index        ": "0.67%",
    "03.read embedded file  ": "2.99%",
    "04.metadata from bytes ": "4.79%",
    "05.choose entry        ": "0.06%",
    "06.generate names      ": "0.08%",
    "07.scan stdin          ": "2.21%",
    "08.print speech bubble ": "0.52%",
    "09.read sprite file    ": "4.84%",
    "10.generate string     ": "0.68%",
    "11.gunzip string       ": "3.27%",
    "12.reverse string      ": "28.03%",
    "13.print to terminal   ": "28.53%",
    "14.op                  ": "0.13%"
  },
  "Total": 2222750,
  "AlignKeys": true,
  "Enabled": true
}
```

</details>