### PR TITLE
Dist output

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,8 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Pull image from ghcr.io
         run: docker pull ghcr.io/tmck-code/pokesay:latest
+      - name: Make dist directory
+        run: mkdir -p dist/bin/ dist/packages/ dist/tarballs/
       - name: Build go binary assets
         run: docker run -v ${PWD}:/usr/local/src -e VERSION=latest ghcr.io/tmck-code/pokesay:latest ./build/scripts/build_assets.sh
       - name: Build go binaries

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,9 +19,9 @@ jobs:
       - name: Build go binaries
         run: docker run -v ${PWD}:/usr/local/src ghcr.io/tmck-code/pokesay:latest ./build/scripts/build_bin.sh
       - name: Check build
-        run: ls -alh build/bin
+        run: ls -alh dist/bin
       - name: Test build
-        run: echo w | ./build/bin/pokesay-linux-amd64
+        run: echo w | ./dist/bin/pokesay-*-linux-amd64
       - name: Run unit tests
         run: docker run -v ${PWD}:/usr/local/src ghcr.io/tmck-code/pokesay:latest gotestsum --format dots
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Check build
         run: ls -alh dist/bin
       - name: Test build
-        run: echo w | ./dist/bin/pokesay-*-linux-amd64
+        run: echo w | ./dist/bin/pokesay-latest-linux-amd64
       - name: Run unit tests
         run: docker run -v ${PWD}:/usr/local/src ghcr.io/tmck-code/pokesay:latest gotestsum --format dots
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,9 +15,9 @@ jobs:
       - name: Pull image from ghcr.io
         run: docker pull ghcr.io/tmck-code/pokesay:latest
       - name: Build go binary assets
-        run: docker run -v ${PWD}:/usr/local/src ghcr.io/tmck-code/pokesay:latest ./build/scripts/build_assets.sh
+        run: docker run -v ${PWD}:/usr/local/src -e VERSION=latest ghcr.io/tmck-code/pokesay:latest ./build/scripts/build_assets.sh
       - name: Build go binaries
-        run: docker run -v ${PWD}:/usr/local/src ghcr.io/tmck-code/pokesay:latest ./build/scripts/build_bin.sh
+        run: docker run -v ${PWD}:/usr/local/src -e VERSION=latest ghcr.io/tmck-code/pokesay:latest ./build/scripts/build_bin.sh
       - name: Check build
         run: ls -alh dist/bin
       - name: Test build

--- a/build/Makefile
+++ b/build/Makefile
@@ -34,19 +34,17 @@ build/bin: build/assets
 	@mkdir -p $(PWD)/../dist/bin/ $(PWD)/../dist/packages/ $(PWD)/../dist/tarballs/
 	@docker run \
 		-v $(PWD)/../:/usr/local/src \
-		-v $(PWD)/../dist/:/usr/local/src/dist/ \
 		-e VERSION=$(VERSION) \
 		--user root \
 		--rm --name pokesay \
 		  $(DOCKER_IMAGE) \
 		  build/scripts/build_bin.sh
-	@tree $(PWD)/../dist/bin/
+	@tree $(PWD)/../dist/
 
 build/deb:
 	@echo -e "\n> Building DEB packages"
 	@docker run \
 		-v $(PWD)/../:/usr/local/src \
-		-v $(PWD)/../dist/:/usr/local/src/dist/ \
 		-e VERSION=$(VERSION) \
 		--rm \
 		--name pokesay \
@@ -58,7 +56,6 @@ build/arch:
 	@docker run \
 		-it \
 		-v $(PWD)/../:/usr/local/src \
-		-v $(PWD)/../dist/:/usr/local/src/dist/ \
 		-e VERSION=$(VERSION) \
 		--platform linux/amd64 \
 		--rm \

--- a/build/Makefile
+++ b/build/Makefile
@@ -23,25 +23,30 @@ build/cows:
 
 # generate embedded bin files for category/metadata/the actual pokemon
 build/assets:
-	docker run \
+	@docker run \
 		-v $(PWD)/../:/usr/local/src \
 		--rm --name pokesay \
 	    $(DOCKER_IMAGE) \
 			build/scripts/build_assets.sh
 
 build/bin: build/assets
-	docker run \
+	@echo -e "\n> Building binaries"
+	@mkdir -p $(PWD)/../dist/bin/ $(PWD)/../dist/packages/ $(PWD)/../dist/tarballs/
+	@docker run \
 		-v $(PWD)/../:/usr/local/src \
+		-v $(PWD)/../dist/:/usr/local/src/dist/ \
+		-e VERSION=$(VERSION) \
 		--user root \
 		--rm --name pokesay \
 		  $(DOCKER_IMAGE) \
 		  build/scripts/build_bin.sh
-	tree $(PWD)/bin/
+	@tree $(PWD)/../dist/bin/
 
 build/deb:
-	@echo "\n> Building DEB packages"
+	@echo -e "\n> Building DEB packages"
 	@docker run \
 		-v $(PWD)/../:/usr/local/src \
+		-v $(PWD)/../dist/:/usr/local/src/dist/ \
 		-e VERSION=$(VERSION) \
 		--rm \
 		--name pokesay \
@@ -49,20 +54,21 @@ build/deb:
 		  bash -c "/usr/local/src/build/scripts/build_packages.sh deb"
 
 build/arch:
-	@echo "\n> Building Arch packages"
+	@echo -e "\n> Building Arch packages"
 	@docker run \
 		-it \
 		-v $(PWD)/../:/usr/local/src \
+		-v $(PWD)/../dist/:/usr/local/src/dist/ \
 		-e VERSION=$(VERSION) \
 		--platform linux/amd64 \
 		--rm \
 		--name pokesay \
 		  archlinux:base-devel \
-		  bash -c "useradd u -m && su - u -c 'bash /usr/local/src/build/scripts/build_packages.sh arch'"
+		  bash -c "useradd u -m && su - u -c 'VERSION=$(VERSION) bash /usr/local/src/build/scripts/build_packages.sh arch'"
 
 build/packages: build/deb build/arch
-	@echo "\n> Built packages:"
-	@ls -alh $(PWD)/packages/
+	@echo -e "\n> Built packages:"
+	@tree $(PWD)/../dist/
 
 test:
 	docker run \

--- a/build/packages/pokesay.1
+++ b/build/packages/pokesay.1
@@ -1,4 +1,4 @@
-.TH POKESAY 1 "September 2025" "pokesay 0.17.0" "User Commands"
+.TH POKESAY 1 "October 2025" "pokesay 0.18.1" "User Commands"
 .SH NAME
 pokesay \- print Pokémon in the CLI! An adaptation of the classic "cowsay"
 .SH SYNOPSIS

--- a/build/scripts/build_bin.sh
+++ b/build/scripts/build_bin.sh
@@ -2,13 +2,28 @@
 
 set -euo pipefail
 
-OUTPUT_DIR="build/bin"
+[ -z "${VERSION:-}" ] && exit 1
+
+OUTPUT_DIR="dist/bin"
 mkdir -p "$OUTPUT_DIR"
 
+cp build/packages/pokesay.1 .
+
 function build() {
-    echo "building $1 / $2"
-    GOOS=$1 GOARCH=$2 go build -o "${OUTPUT_DIR}/pokesay-${1}-${2}${3:-}" pokesay.go
-    echo "- built as ${OUTPUT_DIR}/pokesay-${1}-${2}${3:-}"
+    echo "- building $1 / $2"
+    GOOS=$1 GOARCH=$2 go build -o "${OUTPUT_DIR}/pokesay-${VERSION}-${1}-${2}${3:-}" pokesay.go
+    echo "- built as ${OUTPUT_DIR}/pokesay-${VERSION}-${1}-${2}${3:-}"
+}
+
+function tarball() {
+    echo "- tarballing $1 / $2"
+    cp "${OUTPUT_DIR}/pokesay-${VERSION}-${1}-${2}${3:-}" .
+
+    tar czf \
+        "dist/tarballs/pokesay-${VERSION}-${1}-${2}${3:-}.tar.gz" \
+        "pokesay-${VERSION}-${1}-${2}${3:-}" LICENSE pokesay.1
+
+    rm -f "pokesay-${VERSION}-${1}-${2}${3:-}"
 }
 
 build darwin  amd64 &
@@ -17,3 +32,8 @@ build linux   amd64 &
 build windows amd64 .exe &
 build android arm64 &
 wait
+
+# just create a tarball for the linux/amd64 (used for AUR package)
+tarball linux amd64
+
+rm -f pokesay.1

--- a/build/scripts/build_packages.sh
+++ b/build/scripts/build_packages.sh
@@ -20,11 +20,11 @@ function build_deb() {
     local arch=$2
     local suffix=${3:-}
 
-    OUTPUT_DIR="build/deb"
+    OUTPUT_DIR="dist/packages"
     mkdir -p "$OUTPUT_DIR"
 
-    local bin="build/bin/pokesay-${os}-${arch}${suffix}"
-    local pkg_name="pokesay-${os}-${arch}"
+    local bin="dist/bin/pokesay-${VERSION}-${os}-${arch}${suffix}"
+    local pkg_name="pokesay-${VERSION}-${os}-${arch}"
 
     mkdir -p "$pkg_name/pokesay/DEBIAN" "$pkg_name/pokesay/usr/bin" "$pkg_name/pokesay/usr/share/man/man1"
 
@@ -44,10 +44,9 @@ Maintainer: $MAINTAINER
 Description: $DESCRIPTION
 EOF
 
-    dpkg-deb --build "$pkg_name/pokesay/" "$OUTPUT_DIR/pokesay_${VERSION}_${arch}.deb"
+    dpkg-deb --build "$pkg_name/pokesay/" "$OUTPUT_DIR/pokesay-${VERSION}-${os}-${arch}.deb"
 
     rm -rf "$pkg_name"
-    mv -v "$OUTPUT_DIR/pokesay_${VERSION}_${arch}.deb" /usr/local/src/build/packages/
 }
 
 function build_arch() {
@@ -61,8 +60,9 @@ function build_arch() {
     ARCH_DIR="/usr/local/src/build/arch"
     mkdir -p "$ARCH_DIR"
 
-    cp "build/bin/pokesay-${os}-${arch}${suffix}" "$ARCH_DIR/"
+    cp "dist/bin/pokesay-${VERSION}-${os}-${arch}${suffix}" "$ARCH_DIR/"
     cp "build/packages/pokesay.1" "$ARCH_DIR/"
+    cp LICENSE "$ARCH_DIR/"
 
     cat > "$ARCH_DIR/PKGBUILD" <<EOF
 # Maintainer: $MAINTAINER
@@ -75,18 +75,20 @@ arch=('$arch_arch')
 url="https://github.com/tmck-code/pokesay"
 license=('BSD-3-Clause')
 depends=()
-source=("pokesay-linux-amd64")
+source=("pokesay-${VERSION}-${os}-${arch}${suffix}")
 sha256sums=('SKIP')
 
 package() {
-    install -Dm755 "\$srcdir/pokesay-linux-amd64" "\$pkgdir/usr/bin/pokesay"
+    install -Dm755 "\$srcdir/pokesay-${VERSION}-${os}-${arch}${suffix}" "\$pkgdir/usr/bin/pokesay"
     install -Dm644 "\$srcdir/../pokesay.1" "\$pkgdir/usr/share/man/man1/pokesay.1"
+    install -Dm644 "\$srcdir/../LICENSE" "\$pkgdir/usr/share/licenses/pokesay/LICENSE"
 }
 EOF
     cd "$ARCH_DIR"
+    makepkg --printsrcinfo > .SRCINFO
     makepkg -f --noconfirm
 
-    mv -v "$ARCH_DIR"/*.pkg.tar.zst /usr/local/src/build/packages/
+    cp "$ARCH_DIR"/*.pkg.tar.zst /usr/local/src/dist/packages/
     rm -rf "$ARCH_DIR"
 }
 

--- a/build/scripts/install.sh
+++ b/build/scripts/install.sh
@@ -7,26 +7,28 @@ GOARCH="$2"
 VERSION="${3:-latest}"
 
 function get_latest_version() {
-   curl -s https://api.github.com/repos/tmck-code/pokesay/releases/latest \
-     | grep tag_name \
-     | cut -d "\"" -f 4- \
-     | sed 's/",$//g'
+  curl -s https://api.github.com/repos/tmck-code/pokesay/releases/latest \
+    | grep tag_name \
+    | cut -d "\"" -f 4- \
+    | sed 's/",$//g'
+    | tr -d 'v'
 }
 
 # Downloads the release corresponding to the VERSION, GOOS and GOARCH arguments
 function download_bin() {
-  local pokesay_bin="pokesay-$GOOS-$GOARCH"
   local release_version="$VERSION"
 
   if [ "$VERSION" == "latest" ]; then
     echo "- No specific release version given, finding latest version..."
     release_version=$(get_latest_version)
   fi
+
+  local pokesay_bin="pokesay-$release_version-$GOOS-$GOARCH"
   if [ "$GOOS" == "windows" ]; then
     pokesay_bin="${pokesay_bin}.exe"
   fi
 
-  url="https://github.com/tmck-code/pokesay/releases/download/${release_version}/${pokesay_bin}"
+  url="https://github.com/tmck-code/pokesay/releases/download/v${release_version}/${pokesay_bin}"
   echo "- VERSION: $release_version, GOOS=$GOOS, GOARCH=$GOARCH"
 
   # check if the release version is 0.13.0 or later
@@ -35,7 +37,7 @@ function download_bin() {
   if test -f $HOME/bin/pokesay; then
     echo "- Checking for breaking changes in $release_version..."
 
-    if [ $release_version == "v0.13.0" ]; then
+    if [ $release_version == "0.13.0" ]; then
       continue="n"
       echo -e "\nWARNING: This version of pokesay has breaking changes to the CLI args!"
       echo -e "         Please check the release for the changes to the CLI args:"


### PR DESCRIPTION
## Context

This PR marches along the road towards deploying this on homebrew, AUR and others.

- binaries are now versioned like the OS packages
- added tarballs that contain the binary, LICENSE and manpage
- write all binaries, OS packages & tarballs to dist/, i.e.
  ```
  dist/
  ├── bin
  │   ├── pokesay-0.18.1-android-arm64
  │   ├── pokesay-0.18.1-darwin-amd64
  │   ├── pokesay-0.18.1-darwin-arm64
  │   ├── pokesay-0.18.1-linux-amd64
  │   └── pokesay-0.18.1-windows-amd64.exe
  ├── packages
  │   ├── pokesay-0.18.1-1-x86_64.pkg.tar.zst
  │   ├── pokesay-0.18.1-android-arm64.deb
  │   ├── pokesay-0.18.1-linux-amd64.deb
  │   └── pokesay-debug-0.18.1-1-x86_64.pkg.tar.zst
  └── tarballs
      └── pokesay-0.18.1-linux-amd64.tar.gz
  ```
- This now requires running the build task with a VERSION:
  ```
  VERSION=0.18.1 make build/bin build/packages
  ```
- These files can then all be uploaded as part of a release.
- Then, afterward, the binaries/tarballs can be referenced in AUR and homebrew packages.